### PR TITLE
Add support for MUX Selector Port

### DIFF
--- a/editor/js/nodes.js
+++ b/editor/js/nodes.js
@@ -886,7 +886,9 @@ RED.nodes = (function() {
                     var wires = (n.wires[w1] instanceof Array)?n.wires[w1]:[n.wires[w1]];
                     for (var w2=0;w2<wires.length;w2++) {
                         if (wires[w2].node in node_map) {
-                            var link = {source:n,sourcePort:w1,target:node_map[wires[w2].node],targetPort:wires[w2].port};
+                            var targetNode = node_map[wires[w2].node];
+                            var hasSelector = typeof targetNode.hasSelector !== 'undefined' ? targetNode.hasSelector : targetNode._def.hasSelector || false;
+                            var link = {source:n,sourcePort:w1,target:targetNode,targetPort:wires[w2].port};
                             addLink(link);
                             new_links.push(link);
                         }

--- a/editor/sass/flow.scss
+++ b/editor/sass/flow.scss
@@ -121,6 +121,10 @@
     cursor: crosshair;
 }
 
+.port_selector > .port {
+  fill: yellow;
+}
+
 .port_highlight {
     stroke: #6DA332;
     stroke-width: 3;
@@ -177,7 +181,7 @@
     text-anchor:start;
 }
 
-.port_hovered {
+.port_hovered, .port_selector > .port_hovered {
     stroke: $port-selected-color;
     fill:  $port-selected-color;
 }


### PR DESCRIPTION
Adding MUX Support. To add to a node, simply add a property "hasSelector" with a value of true. If added to a node, then msg.port === 0 will always be the selector value.
